### PR TITLE
Add the tree-sitter settings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,15 @@
     "eslint-plugin-n": "^15.2.4",
     "eslint-plugin-promise": "^6.0.0",
     "tree-sitter-cli": "^0.20.6"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.pm",
+      "file-types": [
+        "pm",
+        "pl"
+      ],
+      "first-line-regex": "#!.*\\bperl\\b"
+    }
+  ]
 }


### PR DESCRIPTION
tree-sitter's own highlight command will look in these files for hints on when to apply it to various files. By putting this here it means that `tree-sitter highlight lib/Thing.pm` knows what to do.