### PR TITLE
Implement proper highlighting of array/hash element expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -199,13 +199,13 @@ module.exports = grammar({
 
     array_element_expression: $ => choice(
       // perly.y matches scalar '[' expr ']' here but that would yield a scalar var node
-      seq(field('array', seq('$', $._indirob)),    '[', field('index', $._expr), ']'),
+      seq(field('array', $.container_variable),    '[', field('index', $._expr), ']'),
       prec.left(TERMPREC.ARROW, seq($._term, '->', '[', field('index', $._expr), ']')),
       seq($._subscripted,                          '[', field('index', $._expr), ']'),
     ),
     hash_element_expression: $ => choice(
       // perly.y matches scalar '{' expr '}' here but that would yield a scalar var node
-      seq(field('hash', seq('$', $._indirob)),     '{', field('key', $._expr), '}'),
+      seq(field('hash', $.container_variable),     '{', field('key', $._expr), '}'),
       prec.left(TERMPREC.ARROW, seq($._term, '->', '{', field('key', $._expr), '}')),
       seq($._subscripted,                          '{', field('key', $._expr), '}'),
     ),
@@ -213,6 +213,8 @@ module.exports = grammar({
       seq('(', optional(field('list', $._expr)), ')', '[', $._expr, ']'),
       seq(field('list', $.quoted_word_list), '[', $._expr, ']'),
     ),
+    // this needs to be a named node so highlights.scm can capture it
+    container_variable: $ => seq('$', $._indirob),
 
     _term: $ => choice(
       $.assignment_expression,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -30,6 +30,8 @@
 (scalar_deref_expression ["->" "$" "*"] @variable)
 (array_deref_expression ["->" "@" "*"] @variable)
 (hash_deref_expression ["->" "%" "*"] @variable)
+(array_element_expression [array:(_) "->" "[" "]"] @variable)
+(hash_element_expression [hash:(_) "->" "{" "}"] @variable)
 
 (use_statement (package) @type)
 (package_statement (package) @type)

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -72,7 +72,6 @@ $sref->$*;
 --------------------------------------------------------------------------------
 
 (source_file
-  ; TODO: It'd be nice to see if we can get these two to parse the same
   (expression_statement (scalar (scalar)))
   (expression_statement (scalar_deref_expression (scalar))))
 ================================================================================
@@ -83,7 +82,6 @@ $aref->@*;
 --------------------------------------------------------------------------------
 
 (source_file
-  ; TODO: It'd be nice to see if we can get these two to parse the same
   (expression_statement (array (scalar)))
   (expression_statement (array_deref_expression (scalar))))
 ================================================================================
@@ -94,7 +92,6 @@ $href->%*;
 --------------------------------------------------------------------------------
 
 (source_file
-  ; TODO: It'd be nice to see if we can get these two to parse the same
   (expression_statement (hash (scalar)))
   (expression_statement (hash_deref_expression (scalar))))
 ================================================================================
@@ -113,7 +110,6 @@ $gref->**;
 --------------------------------------------------------------------------------
 
 (source_file
-  ; TODO: It'd be nice to see if we can get these two to parse the same
   (expression_statement (glob (scalar)))
   (expression_statement (glob_deref_expression (scalar))))
 ================================================================================

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -57,11 +57,21 @@ $a[1][2][3];
 --------------------------------------------------------------------------------
 (source_file
   (expression_statement
-    (array_element_expression (number)))
+    (array_element_expression
+      array: (container_variable)
+      index: (number)))
   (expression_statement
-    (array_element_expression (scalar) (number)))
+    (array_element_expression
+      (scalar)
+      index: (number)))
   (expression_statement
-    (array_element_expression (array_element_expression (array_element_expression (number)) (number)) (number))))
+    (array_element_expression
+      (array_element_expression
+        (array_element_expression
+          array: (container_variable)
+          index: (number))
+        index: (number))
+      index: (number))))
 ================================================================================
 hash elements
 ================================================================================
@@ -71,8 +81,18 @@ $h{1}{2}{3};
 --------------------------------------------------------------------------------
 (source_file
   (expression_statement
-    (hash_element_expression (number)))
+    (hash_element_expression
+      hash: (container_variable)
+      key: (number)))
   (expression_statement
-    (hash_element_expression (scalar) (number)))
+    (hash_element_expression
+      (scalar)
+      key: (number)))
   (expression_statement
-    (hash_element_expression (hash_element_expression (hash_element_expression (number)) (number)) (number))))
+    (hash_element_expression
+      (hash_element_expression
+        (hash_element_expression
+          hash: (container_variable)
+          key: (number))
+        key: (number))
+      key: (number))))

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -17,3 +17,36 @@ $aref->@*;
 $href->%*;
 # <- variable
 #    ^^^^ variable
+$arr[ 123 ];
+# <- variable
+# ^^ variable
+#   ^ variable
+#     ^^^ number
+#         ^ variable
+$aref->[ 123 ];
+# <- variable
+#    ^^^ variable
+#        ^^^ number
+#            ^ variable
+$hash{ 123 };
+# <- variable
+# ^^^ variable
+#    ^ variable
+#      ^^^ number
+#          ^ variable
+$href->{ 123 };
+# <- variable
+#    ^^^ variable
+#        ^^^ number
+#            ^ variable
+$aref->[ 123 ]{ 456 }[ 789 ];
+# <- variable
+#    ^^^ variable
+#        ^^^ number
+#            ^ variable
+#             ^ variable
+#               ^^^ number
+#                   ^ variable
+#                    ^ variable
+#                      ^^^ number
+#                          ^ variable


### PR DESCRIPTION
Makes `$array[123]` and `$aref->[123]` look like a variable, while being careful not to highlight all of the LHS as variable, so things like `func_call_here()->[123]` don't highlight the entire function call as a variable.
Does the same for hash access.