### PR TITLE
Autoquoted barewords

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -181,7 +181,9 @@ module.exports = grammar({
     ),
     /* ensure that an entire list expression's contents appear in one big flat
     * list, while permitting multiple internal commas and an optional trailing one */
-    list_expression: $ => seq($._term, ',', repeat(seq(optional($._term), ',')), optional($._term)),
+    list_expression: $ => seq(
+      $._term, $._PERLY_COMMA, repeat(seq(optional($._term), $._PERLY_COMMA)), optional($._term)
+    ),
 
     _subscripted: $ => choice(
       /* TODO:
@@ -429,6 +431,8 @@ module.exports = grammar({
     _NCEQOP: $ => choice('<=>', 'cmp', '~~'),
     _NCRELOP: $ => choice('isa'),
     _REFGEN: $ => '\\',
+
+    _PERLY_COMMA: $ => choice(',', '=>'),
 
     _KW_USE: $ => choice('use', 'no'),
     _KW_FOR: $ => choice('for', 'foreach'),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -35,6 +35,8 @@
 (array_element_expression [array:(_) "->" "[" "]"] @variable)
 (hash_element_expression [hash:(_) "->" "{" "}"] @variable)
 
+(hash_element_expression key: (bareword) @string.special)
+
 (use_statement (package) @type)
 (package_statement (package) @type)
 (require_expression (bareword) @type)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -26,6 +26,8 @@
 (quoted_word_list) @string
 [(escape_sequence) (escaped_delimiter)] @string.special
 
+(_ (bareword) @string.special . "=>")
+
 [(scalar) (array) (hash)] @variable
 (scalar_deref_expression ["->" "$" "*"] @variable)
 (array_deref_expression ["->" "@" "*"] @variable)

--- a/test/corpus/operators
+++ b/test/corpus/operators
@@ -20,10 +20,12 @@ EXPR, EXPR
 1, 2, 3;
 1, 2,;
 1,,3;
+1 => 4;
 --------------------------------------------------------------------------------
 
 (source_file
   (expression_statement (list_expression (number) (number) (number)))
+  (expression_statement (list_expression (number) (number)))
   (expression_statement (list_expression (number) (number)))
   (expression_statement (list_expression (number) (number))))
 ================================================================================

--- a/test/highlight/operators.pm
+++ b/test/highlight/operators.pm
@@ -10,3 +10,7 @@
 #  ^ operator
 12 isa 34;
 #  ^ operator
+%hash = (foo => "bar");
+# <- variable
+#        ^^^ string.special
+#               ^^^^^ string

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -28,16 +28,16 @@ $aref->[ 123 ];
 #    ^^^ variable
 #        ^^^ number
 #            ^ variable
-$hash{ 123 };
+$hash{ key };
 # <- variable
 # ^^^ variable
 #    ^ variable
-#      ^^^ number
+#      ^^^ string.special
 #          ^ variable
-$href->{ 123 };
+$href->{ key };
 # <- variable
 #    ^^^ variable
-#        ^^^ number
+#        ^^^ string.special
 #            ^ variable
 $aref->[ 123 ]{ 456 }[ 789 ];
 # <- variable


### PR DESCRIPTION
Adds highlight rules to two situations to highlight them as special strings:

 * Bareword on LHS of `=>`
 * Bareword as hash key of `->{ KEY }`