### PR TITLE
Handle `undef` as an expression type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -264,6 +264,7 @@ module.exports = grammar({
       $.glob_deref_expression,
       $.loopex_expression,
       $.goto_expression,
+      $.undef_expression,
       /* NOTOP listexpr
        * UNIOP
        * UNIOP block
@@ -389,6 +390,11 @@ module.exports = grammar({
       prec.left(TERMPREC.LOOPEX, seq(field('loopex', $._LOOPEX), optional($._term))),
     goto_expression: $ =>
       prec.left(TERMPREC.LOOPEX, seq('goto', $._term)),
+
+    /* Perl just considers `undef` like any other UNIOP but it's quite likely
+     * that tree consumers and highlighters would want to handle it specially
+     */
+    undef_expression: $ => prec.left(TERMPREC.UNOP, seq('undef', optional($._term))),
 
     _listop: $ => choice(
       /* TODO:

--- a/grammar.js
+++ b/grammar.js
@@ -365,8 +365,7 @@ module.exports = grammar({
         field('variable', $.array),
         field('variable', $.hash),
         field('variables', $._paren_list_of_variables))),
-    _variable: $ => choice($.scalar, $.array, $.hash),
-    // TODO: permit undef in a var list
+    _variable: $ => choice($.scalar, $.array, $.hash, $.undef_expression),
     _paren_list_of_variables: $ =>
       seq('(', repeat(seq(optional($._variable), ',')), optional($._variable), ')'),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -8,6 +8,7 @@
   "my"
   "require"
   "last" "next" "redo" "goto"
+  "undef"
 ] @keyword
 
 [

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -142,3 +142,13 @@ goto LABEL;
 
 (source_file
   (expression_statement (goto_expression (bareword))))
+================================================================================
+undef
+================================================================================
+undef;
+undef $var;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement (undef_expression))
+  (expression_statement (undef_expression (scalar))))

--- a/test/corpus/variables
+++ b/test/corpus/variables
@@ -35,6 +35,13 @@ my ($S, @A, %h);
   (expression_statement (variable_declaration (hash)))
   (expression_statement (variable_declaration (scalar) (array) (hash))))
 ================================================================================
+variable declarations including undef
+================================================================================
+my ($x, undef, $z);
+--------------------------------------------------------------------------------
+(source_file
+  (expression_statement (variable_declaration (scalar) (undef_expression) (scalar))))
+================================================================================
 variable declarations with initialiser
 ================================================================================
 my $s = 123;

--- a/test/highlight/expressions.pm
+++ b/test/highlight/expressions.pm
@@ -14,3 +14,8 @@ redo;
 # <- keyword
 goto LABEL;
 # <- keyword
+undef;
+# <- keyword
+undef $var;
+# <- keyword
+#     ^ variable.scalar

--- a/test/highlight/variables.pm
+++ b/test/highlight/variables.pm
@@ -8,6 +8,11 @@ $one + $two;
 my $var;
 # <- keyword
 #  ^ variable.scalar
+my ($x, undef, $z);
+# <- keyword
+#   ^ variable.scalar
+#       ^ keyword
+#              ^ variable.scalar
 $sref->$*;
 # <- variable.scalar
 #    ^^^^ variable.scalar


### PR DESCRIPTION
Handled specially so that
 * We can put it in `my (LIST)`
 * Tree consumers and highlighters can easily distinguish it