### PR TITLE
Extract POD as plaintext

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -64,10 +64,12 @@ module.exports = grammar({
     $._qw_list_content,
     $.escape_sequence,
     $.escaped_delimiter,
+    $.pod,
   ],
   extras: $ => [
     /\s|\\\r?\n/,
     $.comment,
+    $.pod,
   ],
   conflicts: $ => [
     [ $.preinc_expression, $.postinc_expression ],

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -19,6 +19,8 @@
 
 (comment) @comment
 
+(pod) @text
+
 (number) @number
 (version) @number
 

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,2 @@
+; an injections.scm file for nvim-treesitter
+(pod) @pod

--- a/test/corpus/pod
+++ b/test/corpus/pod
@@ -1,0 +1,49 @@
+================================================================================
+POD
+================================================================================
+=head1 NAME
+
+Foo
+
+=cut
+1234;
+
+=head2 Things
+
+=cut
+
+5678;
+--------------------------------------------------------------------------------
+(source_file
+  (pod)
+  (expression_statement (number))
+  (pod)
+  (expression_statement (number)))
+================================================================================
+not confused by leading whitespace
+================================================================================
+my $x
+  =head1() ;
+--------------------------------------------------------------------------------
+(source_file
+  (expression_statement
+    (assignment_expression
+      (variable_declaration (scalar))
+      (function_call_expression (function)))))
+================================================================================
+POD can appear anywhere within an expression
+================================================================================
+my $total =
+  1 +
+
+=head1 TITLE
+
+=cut
+
+  2;
+--------------------------------------------------------------------------------
+(source_file
+  (expression_statement
+    (assignment_expression
+      (variable_declaration (scalar))
+      (binary_expression (number) (pod) (number)))))


### PR DESCRIPTION
We don't need to worry about any detailed highlighting within it, because that's what `tree-sitter-pod` is for.